### PR TITLE
Only use one Python version specifier in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version-file: "pyproject.toml"
 
       - name: 🔨 Install dependencies
         run: uv sync --no-default-groups --group test


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify GitHub Actions workflow to dynamically read Python version from pyproject.toml, removing the hardcoded Python 3.11 version specifier